### PR TITLE
Change aws instance type to m5.2xlarge

### DIFF
--- a/src/service/cluster.py
+++ b/src/service/cluster.py
@@ -48,7 +48,7 @@ class ClusterService:
         "name": "",
         "nodes": {
             "compute": 3,
-            "compute_machine_type": {"id": "m5.4xlarge"},
+            "compute_machine_type": {"id": "m5.2xlarge"},
         },
         "region": {"id": env("AWS_REGION")},
     }


### PR DESCRIPTION
The pre-requisite for AWS instance type for ODF MS dev provider addon was changed
from m5.4xlarge to m5.2xlarge.
https://gitlab.cee.redhat.com/service/managed-tenants/-/merge_requests/2477
